### PR TITLE
Add missing import statement

### DIFF
--- a/src/android/ViewLib/src/main/java/com/radaee/reader/PDFPagerAct.java
+++ b/src/android/ViewLib/src/main/java/com/radaee/reader/PDFPagerAct.java
@@ -13,6 +13,7 @@ import com.radaee.pdf.Global;
 import com.radaee.util.PDFAssetStream;
 import com.radaee.util.PDFHttpStream;
 import com.radaee.view.PDFViewPager;
+import com.radaee.viewlib.R;
 
 import java.util.Locale;
 


### PR DESCRIPTION
Building a Cordova app with the Radaee PDF plugin leads to the following error:

```
project-root\platforms\android\app\src\main\java\com\radaee\reader\PDFPagerAct.java:18: error: cannot find symbol
import com.radaee.cordova.R;
                         ^
  symbol:   class R
  location: package com.radaee.cordova
project-root\platforms\android\app\src\main\java\com\radaee\reader\PDFPagerAct.java:43: error: package R does not exist
                onFail(getString(R.string.failed_invalid_password));
                                  ^
project-root\platforms\android\app\src\main\java\com\radaee\reader\PDFPagerAct.java:46: error: package R does not exist
                onFail(getString(R.string.failed_encryption));
                                  ^
project-root\platforms\android\app\src\main\java\com\radaee\reader\PDFPagerAct.java:49: error: package R does not exist
                onFail(getString(R.string.failed_invalid_format));
                                  ^
project-root\platforms\android\app\src\main\java\com\radaee\reader\PDFPagerAct.java:52: error: package R does not exist
                onFail(getString(R.string.failed_invalid_path));
                                  ^
project-root\platforms\android\app\src\main\java\com\radaee\reader\PDFPagerAct.java:58: error: package R does not exist
                onFail(getString(R.string.failed_unknown));
                                  ^
project-root\platforms\android\app\src\main\java\com\radaee\reader\PDFPagerAct.java:68: error: package R does not exist
        m_pager = (PDFViewPager)m_layout.findViewById(R.id.pdf_pager);
                                                       ^
```

The `import com.radaee.<something>.R` statements are replaced with the app's namespace during build using a cordova hook. The file that causes the error above is included in that hook script:
https://github.com/gearit/RadaeePDF-Cordova/blob/master/src/android/hooks/configure-android.js#L87

However, the import statement that this script is trying to replace is missing. Adding it fixes the problem.
